### PR TITLE
Fixes the issue with line number when parsing several files

### DIFF
--- a/lib/simplabs/excellent/parsing/parser.rb
+++ b/lib/simplabs/excellent/parsing/parser.rb
@@ -19,7 +19,11 @@ module Simplabs
         private
 
           def silent_parse(content, filename)
-            @parser ||= RUBY_VERSION =~ /2\.0/ ? Ruby19Parser.new : RubyParser.for_current_ruby
+            if @parser.nil?
+              @parser = RUBY_VERSION =~ /2\.0/ ? Ruby19Parser.new : RubyParser.for_current_ruby
+            else
+              @parser.reset
+            end
             content = ::ERB.new(content, nil, '-').src if filename =~ /\.erb$/
             sexp = @parser.parse(content, filename)
             sexp


### PR DESCRIPTION
Hi guys,

I found excellent, well... quite excellent, but I was really annoyed about the issue with the line numbers when excellentizing several files at once.

Example:
Assuming that I used the snipped of the README:

```
class ShoppingBasket < ActiveRecord::Base
  def initialize(items = [])
    self.items = items
  end
end
```

And copy/paste it in 3 files r1.rb, r2.rb and r3.rb in the folder test, the command:

```
excellent test/
```

would return:

```
  Excellent result:

  test/r1.rb
    * Line   1: ShoppingBasket does not specify attr_accessible.
    * Line   1: ShoppingBasket does not validate any attributes.
    * Line   1: ShoppingBasket defines initialize method.

  test/r2.rb
    * Line   6: ShoppingBasket does not specify attr_accessible.
    * Line   6: ShoppingBasket does not validate any attributes.
    * Line   6: ShoppingBasket defines initialize method.

  test/r3.rb
    * Line  11: ShoppingBasket does not specify attr_accessible.
    * Line  11: ShoppingBasket does not validate any attributes.
    * Line  11: ShoppingBasket defines initialize method.

  Found 9 warnings.
```

By resetting the parser, we now have a results with corrects line numbers:

```
  Excellent result:

  test/r1.rb
    * Line   1: ShoppingBasket does not specify attr_accessible.
    * Line   1: ShoppingBasket does not validate any attributes.
    * Line   1: ShoppingBasket defines initialize method.

  test/r2.rb
    * Line   1: ShoppingBasket does not specify attr_accessible.
    * Line   1: ShoppingBasket does not validate any attributes.
    * Line   1: ShoppingBasket defines initialize method.

  test/r3.rb
    * Line   1: ShoppingBasket does not specify attr_accessible.
    * Line   1: ShoppingBasket does not validate any attributes.
    * Line   1: ShoppingBasket defines initialize method.

  Found 9 warnings.
```

Yay !

Keep up the good work, guys, and thank you for excellent !
